### PR TITLE
chore: add client data to session destroy broadcast event

### DIFF
--- a/src/handlers/session-cron-task.ts
+++ b/src/handlers/session-cron-task.ts
@@ -37,39 +37,6 @@ export async function handler(pgPool: Pool, redisClient: RedisClient): Promise<v
       const activeSession = await getActiveSession(logger, redisClient, connectionId);
 
       if (!activeSession) {
-        // const rooms = await getCachedRooms(logger, redisClient, connectionId);
-
-        // if (rooms && rooms.length > 0) {
-        //   await Promise.all(
-        //     rooms.map(async (nspRoomId) =>
-        //       Promise.all([
-        //         purgeCachedRooms(logger, redisClient, connectionId),
-        //         purgeSubscriptions(
-        //           logger,
-        //           redisClient,
-        //           connectionId,
-        //           nspRoomId,
-        //           KeyNamespace.SUBSCRIPTIONS
-        //         ),
-        //         purgeSubscriptions(
-        //           logger,
-        //           redisClient,
-        //           connectionId,
-        //           nspRoomId,
-        //           KeyNamespace.PRESENCE
-        //         ),
-        //         purgeSubscriptions(
-        //           logger,
-        //           redisClient,
-        //           connectionId,
-        //           nspRoomId,
-        //           KeyNamespace.METRICS
-        //         )
-        //       ])
-        //     )
-        //   );
-        // }
-
         await destroyRoomSubscriptions(logger, redisClient, connectionId);
         await destroyUserSubscriptions(logger, redisClient, connectionId);
         await setSessionDisconnected(logger, pgClient, connectionId);

--- a/src/module/service.ts
+++ b/src/module/service.ts
@@ -175,7 +175,7 @@ export function broadcastSessionDestroy(
   const timestamp = new Date().toISOString();
 
   const data = {
-    clientId: getPublicClientId(uid),
+    clientId: uid,
     event: SubscriptionType.LEAVE,
     timestamp,
     user: sessionData.user

--- a/src/module/service.ts
+++ b/src/module/service.ts
@@ -169,13 +169,13 @@ export function broadcastSessionDestroy(
 
   const subscription = formatPresenceSubscription(nspRoomId, SubscriptionType.LEAVE);
   const timestamp = new Date().toISOString();
-  const { clientId } = sessionData;
+  const { clientId, user } = sessionData;
 
   const data = {
     clientId,
     event: SubscriptionType.LEAVE,
     timestamp,
-    user: sessionData.user
+    user
   };
 
   try {

--- a/src/module/service.ts
+++ b/src/module/service.ts
@@ -36,6 +36,10 @@ export function formatUserSubscriptionAll(nspClientId: string): string {
   return `${nspClientId}:$:$:subscribe:all`;
 }
 
+export function getPublicClientId(clientId: string): string {
+  return clientId.split(':')[1];
+}
+
 export async function getCachedRooms(
   logger: Logger,
   redisClient: RedisClient,
@@ -168,7 +172,14 @@ export function broadcastSessionDestroy(
   logger.debug(`Broadcasting session destroy`, { uid, nspRoomId });
 
   const subscription = formatPresenceSubscription(nspRoomId, SubscriptionType.LEAVE);
-  const data = { uid, message: 'Session disconnect' };
+  const timestamp = new Date().toISOString();
+
+  const data = {
+    clientId: getPublicClientId(uid),
+    event: SubscriptionType.LEAVE,
+    timestamp,
+    user: sessionData.user
+  };
 
   try {
     dispatch(nspRoomId, subscription, data, sessionData);

--- a/src/module/service.ts
+++ b/src/module/service.ts
@@ -169,9 +169,10 @@ export function broadcastSessionDestroy(
 
   const subscription = formatPresenceSubscription(nspRoomId, SubscriptionType.LEAVE);
   const timestamp = new Date().toISOString();
+  const { clientId } = sessionData;
 
   const data = {
-    clientId: uid,
+    clientId,
     event: SubscriptionType.LEAVE,
     timestamp,
     user: sessionData.user

--- a/src/module/service.ts
+++ b/src/module/service.ts
@@ -36,10 +36,6 @@ export function formatUserSubscriptionAll(nspClientId: string): string {
   return `${nspClientId}:$:$:subscribe:all`;
 }
 
-export function getPublicClientId(clientId: string): string {
-  return clientId.split(':')[1];
-}
-
 export async function getCachedRooms(
   logger: Logger,
   redisClient: RedisClient,

--- a/test/module/service.spec.ts
+++ b/test/module/service.spec.ts
@@ -260,7 +260,7 @@ describe('service', () => {
         nspRoomId,
         presenceSubscription,
         expect.objectContaining({
-          clientId: '12345',
+          clientId: sessionData.clientId,
           event: SubscriptionType.LEAVE,
           timestamp: expect.any(String),
           user: sessionData.user

--- a/test/module/service.spec.ts
+++ b/test/module/service.spec.ts
@@ -249,7 +249,7 @@ describe('service', () => {
 
   describe('broadcastSessionDestroy', () => {
     it('should broadcast session destroy event to nspRoomId', () => {
-      const uid = '12345';
+      const uid = '12345:abcde';
       const nspRoomId = 'nsp:room1';
       const sessionData = getMockSession({ uid });
       const presenceSubscription = formatPresenceSubscription(nspRoomId, SubscriptionType.LEAVE);
@@ -259,7 +259,12 @@ describe('service', () => {
       expect(mockPublisher.dispatch).toHaveBeenCalledWith(
         nspRoomId,
         presenceSubscription,
-        expect.objectContaining({ uid }),
+        expect.objectContaining({
+          clientId: 'abcde',
+          event: SubscriptionType.LEAVE,
+          timestamp: expect.any(String),
+          user: sessionData.user
+        }),
         sessionData
       );
     });

--- a/test/module/service.spec.ts
+++ b/test/module/service.spec.ts
@@ -249,7 +249,7 @@ describe('service', () => {
 
   describe('broadcastSessionDestroy', () => {
     it('should broadcast session destroy event to nspRoomId', () => {
-      const uid = '12345:abcde';
+      const uid = '12345';
       const nspRoomId = 'nsp:room1';
       const sessionData = getMockSession({ uid });
       const presenceSubscription = formatPresenceSubscription(nspRoomId, SubscriptionType.LEAVE);
@@ -260,7 +260,7 @@ describe('service', () => {
         nspRoomId,
         presenceSubscription,
         expect.objectContaining({
-          clientId: 'abcde',
+          clientId: '12345',
           event: SubscriptionType.LEAVE,
           timestamp: expect.any(String),
           user: sessionData.user


### PR DESCRIPTION
- Updates broadcast event from session destroy to include `clientId` and 'user`
- Minor session cron logic refactor